### PR TITLE
Add example wasmer host

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -27,7 +27,17 @@ jobs:
 
       - uses: actions-rs/cargo@v1
         with:
+          command: build
+
+      - uses: actions-rs/cargo@v1
+        with:
           command: run
+          args: -p example-wasmer-host
+
+      - uses: actions-rs/cargo@v1
+        with:
+          command: run
+          args: -p example-wasmtime-host
 
   check:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,7 +74,7 @@ checksum = "e7a905d892734eea339e896738c14b9afce22b5318f64b951e70bf3844419b01"
 dependencies = [
  "addr2line",
  "cc",
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "miniz_oxide",
  "object",
@@ -110,6 +110,18 @@ checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "bumpalo"
+version = "3.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9df67f7bf9ef8498769f994239c45613ef0c5899415fb58e9add412d2c1a538"
+
+[[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "cap-fs-ext"
@@ -192,6 +204,12 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
@@ -202,7 +220,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea47428dc9d2237f3c6bc134472edfd63ebba0af932e783506dcfd66f10d18a"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -216,11 +234,37 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
+version = "0.76.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e6bea67967505247f54fa2c85cf4f6e0e31c4e5692c9b70e4ae58e339067333"
+dependencies = [
+ "cranelift-entity 0.76.0",
+]
+
+[[package]]
+name = "cranelift-bforest"
 version = "0.77.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15013642ddda44eebcf61365b2052a23fd8b7314f90ba44aa059ec02643c5139"
 dependencies = [
- "cranelift-entity",
+ "cranelift-entity 0.77.0",
+]
+
+[[package]]
+name = "cranelift-codegen"
+version = "0.76.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48194035d2752bdd5bdae429e3ab88676e95f52a2b1355a5d4e809f9e39b1d74"
+dependencies = [
+ "cranelift-bforest 0.76.0",
+ "cranelift-codegen-meta 0.76.0",
+ "cranelift-codegen-shared 0.76.0",
+ "cranelift-entity 0.76.0",
+ "gimli",
+ "log",
+ "regalloc",
+ "smallvec",
+ "target-lexicon",
 ]
 
 [[package]]
@@ -229,10 +273,10 @@ version = "0.77.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "298f2a7ed5fdcb062d8e78b7496b0f4b95265d20245f2d0ca88f846dd192a3a3"
 dependencies = [
- "cranelift-bforest",
- "cranelift-codegen-meta",
- "cranelift-codegen-shared",
- "cranelift-entity",
+ "cranelift-bforest 0.77.0",
+ "cranelift-codegen-meta 0.77.0",
+ "cranelift-codegen-shared 0.77.0",
+ "cranelift-entity 0.77.0",
  "gimli",
  "log",
  "regalloc",
@@ -242,19 +286,41 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
+version = "0.76.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "976efb22fcab4f2cd6bd4e9913764616a54d895c1a23530128d04e03633c555f"
+dependencies = [
+ "cranelift-codegen-shared 0.76.0",
+ "cranelift-entity 0.76.0",
+]
+
+[[package]]
+name = "cranelift-codegen-meta"
 version = "0.77.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cf504261ac62dfaf4ffb3f41d88fd885e81aba947c1241275043885bc5f0bac"
 dependencies = [
- "cranelift-codegen-shared",
- "cranelift-entity",
+ "cranelift-codegen-shared 0.77.0",
+ "cranelift-entity 0.77.0",
 ]
+
+[[package]]
+name = "cranelift-codegen-shared"
+version = "0.76.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dabb5fe66e04d4652e434195b45ae65b5c8172d520247b8f66d8df42b2b45dc"
 
 [[package]]
 name = "cranelift-codegen-shared"
 version = "0.77.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cd2a72db4301dbe7e5a4499035eedc1e82720009fb60603e20504d8691fa9cd"
+
+[[package]]
+name = "cranelift-entity"
+version = "0.76.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3329733e4d4b8e91c809efcaa4faee80bf66f20164e3dd16d707346bd3494799"
 
 [[package]]
 name = "cranelift-entity"
@@ -267,11 +333,23 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
+version = "0.76.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "279afcc0d3e651b773f94837c3d581177b348c8d69e928104b2e9fccb226f921"
+dependencies = [
+ "cranelift-codegen 0.76.0",
+ "log",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-frontend"
 version = "0.77.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "351c9d13b4ecd1a536215ec2fd1c3ee9ee8bc31af172abf1e45ed0adb7a931df"
 dependencies = [
- "cranelift-codegen",
+ "cranelift-codegen 0.77.0",
  "log",
  "smallvec",
  "target-lexicon",
@@ -283,7 +361,7 @@ version = "0.77.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6df8b556663d7611b137b24db7f6c8d9a8a27d7f29c7ea7835795152c94c1b75"
 dependencies = [
- "cranelift-codegen",
+ "cranelift-codegen 0.77.0",
  "libc",
  "target-lexicon",
 ]
@@ -294,13 +372,13 @@ version = "0.77.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a69816d90db694fa79aa39b89dda7208a4ac74b6f2b8f3c4da26ee1c8bdfc5e"
 dependencies = [
- "cranelift-codegen",
- "cranelift-entity",
- "cranelift-frontend",
+ "cranelift-codegen 0.77.0",
+ "cranelift-entity 0.77.0",
+ "cranelift-frontend 0.77.0",
  "itertools",
  "log",
  "smallvec",
- "wasmparser",
+ "wasmparser 0.80.2",
  "wasmtime-types",
 ]
 
@@ -310,7 +388,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -319,7 +397,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-utils",
 ]
 
@@ -329,7 +407,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
@@ -340,7 +418,7 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-utils",
  "lazy_static",
  "memoffset",
@@ -353,8 +431,43 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "lazy_static",
+]
+
+[[package]]
+name = "darling"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "757c0ded2af11d8e739c4daea1ac623dd1624b06c844cf3f5a39f1bdbd99bb12"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c34d8efb62d0c2d7f60ece80f75e5c63c1588ba68032740494b0b9a996466e3"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ade7bff147130fe5e6d39f089c6bd49ec0250f35d70b2eebf72afdfc919f15cc"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -372,7 +485,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "339ee130d97a610ea5a5872d2bbb130fdf68884ff09d3028b81bec8a1ac23bbc"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "dirs-sys-next",
 ]
 
@@ -382,7 +495,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "dirs-sys-next",
 ]
 
@@ -402,6 +515,27 @@ name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
+name = "enumset"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e76129da36102af021b8e5000dab2c1c30dbef85c1e482beeff8da5dde0e0b0"
+dependencies = [
+ "enumset_derive",
+]
+
+[[package]]
+name = "enumset_derive"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6451128aa6655d880755345d085494cf7561a6bee7c8dc821e5d77e6d267ecd4"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "env_logger"
@@ -447,6 +581,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "example-wasmer-host"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "wasmer",
+ "wasmer-wasi",
+ "witx-bindgen-wasmer",
+]
+
+[[package]]
 name = "example-wasmtime-host"
 version = "0.1.0"
 dependencies = [
@@ -473,6 +617,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "fs-set-times"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -495,6 +645,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generational-arena"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d3b771574f62d0548cee0ad9057857e9fc25d7a3335f140c84f6acd0bf601"
+dependencies = [
+ "cfg-if 0.1.10",
+ "serde",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -510,7 +670,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
 ]
@@ -521,7 +681,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "wasi 0.10.2+wasi-snapshot-preview1",
 ]
@@ -586,6 +746,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "indexmap"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -637,6 +803,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "js-sys"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cc9ffccd38c451a86bf13657df244e9c3f37493cce8e5e21e940963777acc84"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -653,6 +828,16 @@ name = "libc"
 version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8f7255a17a627354f321ef0055d63b898c6fb27eff628af4d1b66b7331edf6"
+
+[[package]]
+name = "libloading"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f84d96438c15fcd6c3f244c8fce01d1e2b9c6b5623e9c711dc9286d8fc92d6a"
+dependencies = [
+ "cfg-if 1.0.0",
+ "winapi",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -672,7 +857,28 @@ version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "loupe"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b6a72dfa44fe15b5e76b94307eeb2ff995a8c5b283b55008940c02e0c5b634d"
+dependencies = [
+ "indexmap",
+ "loupe-derive",
+ "rustversion",
+]
+
+[[package]]
+name = "loupe-derive"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fbfc88337168279f2e9ae06e157cfed4efd3316e14dc96ed074d4f2e6c5952"
+dependencies = [
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -695,6 +901,15 @@ name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+
+[[package]]
+name = "memmap2"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "723e3ebdcdc5c023db1df315364573789f8857c11b631a2fdfad7c00f5c046b4"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "memoffset"
@@ -849,6 +1064,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -864,6 +1103,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd136ff4382c4753fc061cb9e4712ab2af263376b95bbd5bd8cd50c020b78e69"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "ptr_meta"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1047,6 +1306,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "region"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76e189c2369884dce920945e2ddf79b3dff49e071a167dd1817fa9c4c00d512e"
+dependencies = [
+ "bitflags",
+ "libc",
+ "mach",
+ "winapi",
+]
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "rkyv"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb135b3e5e3311f0a254bfb00333f4bac9ef1d89888b84242a89eb8722b09a07"
+dependencies = [
+ "memoffset",
+ "ptr_meta",
+ "rkyv_derive",
+ "seahash",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba8f489f6b6d8551bb15904293c1ad58a6abafa7d8390d15f7ed05a2afcd87d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "rsix"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1102,10 +1405,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61b3909d758bb75c79f23d4736fac9433868679d3ad2ea7a61e3c25cfda9a088"
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "semver"
@@ -1120,6 +1435,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16ae07dd2f88a366f15bd0632ba725227018c69a1c8550a927324f8eb8368bb9"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1140,7 +1464,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b69f9a4c9740d74c5baa3fd2e547f9525fa8088a8a958e0ca2409a514e33f5fa"
 dependencies = [
  "block-buffer",
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "digest",
  "opaque-debug",
@@ -1166,6 +1490,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
@@ -1202,6 +1532,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9bffcddbc2458fa3e6058414599e3c838a022abae82e5c67b4f7f80298d5bff"
 
 [[package]]
+name = "tempfile"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "rand 0.8.4",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1231,6 +1575,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "toml"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1245,7 +1599,7 @@ version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84f96e095c0c82419687c20ddf5cb3eadb61f4e1405923c9dc8e53a1adacbda8"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "log",
  "pin-project-lite",
  "tracing-attributes",
@@ -1366,11 +1720,285 @@ version = "0.1.0"
 dependencies = [
  "quote",
  "syn",
- "witx-bindgen-gen-core",
+ "witx-bindgen-gen-core 0.1.0 (git+https://github.com/bytecodealliance/witx-bindgen)",
  "witx-bindgen-gen-rust-wasm",
  "witx-bindgen-rust",
- "witx2",
+ "witx2 0.1.0 (git+https://github.com/bytecodealliance/witx-bindgen)",
 ]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "632f73e236b219150ea279196e54e610f5dbafa5d61786303d4da54f84e47fce"
+dependencies = [
+ "cfg-if 1.0.0",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a317bf8f9fba2476b4b2c85ef4c4af8ff39c3c7f0cdfeed4f82c34a880aa837b"
+dependencies = [
+ "bumpalo",
+ "lazy_static",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56146e7c495528bf6587663bea13a8eb588d39b36b679d83972e1a2dbbdacf9"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7803e0eea25835f8abdc585cd3021b3deb11543c6fe226dcd30b228857c5c5ab"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
+
+[[package]]
+name = "wasmer"
+version = "2.0.0"
+source = "git+https://github.com/wasmerio/wasmer?branch=get_namespace_exports#35d6c0229c1f85969053d695f89cbdc5586d6392"
+dependencies = [
+ "cfg-if 1.0.0",
+ "indexmap",
+ "js-sys",
+ "loupe",
+ "more-asserts",
+ "target-lexicon",
+ "thiserror",
+ "wasm-bindgen",
+ "wasmer-compiler",
+ "wasmer-compiler-cranelift",
+ "wasmer-derive",
+ "wasmer-engine",
+ "wasmer-engine-dylib",
+ "wasmer-engine-universal",
+ "wasmer-types",
+ "wasmer-vm",
+ "wat",
+ "winapi",
+]
+
+[[package]]
+name = "wasmer-compiler"
+version = "2.0.0"
+source = "git+https://github.com/wasmerio/wasmer?branch=get_namespace_exports#35d6c0229c1f85969053d695f89cbdc5586d6392"
+dependencies = [
+ "enumset",
+ "loupe",
+ "rkyv",
+ "serde",
+ "serde_bytes",
+ "smallvec",
+ "target-lexicon",
+ "thiserror",
+ "wasmer-types",
+ "wasmer-vm",
+ "wasmparser 0.78.2",
+]
+
+[[package]]
+name = "wasmer-compiler-cranelift"
+version = "2.0.0"
+source = "git+https://github.com/wasmerio/wasmer?branch=get_namespace_exports#35d6c0229c1f85969053d695f89cbdc5586d6392"
+dependencies = [
+ "cranelift-codegen 0.76.0",
+ "cranelift-entity 0.76.0",
+ "cranelift-frontend 0.76.0",
+ "gimli",
+ "loupe",
+ "more-asserts",
+ "rayon",
+ "smallvec",
+ "tracing",
+ "wasmer-compiler",
+ "wasmer-types",
+ "wasmer-vm",
+]
+
+[[package]]
+name = "wasmer-derive"
+version = "2.0.0"
+source = "git+https://github.com/wasmerio/wasmer?branch=get_namespace_exports#35d6c0229c1f85969053d695f89cbdc5586d6392"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "wasmer-engine"
+version = "2.0.0"
+source = "git+https://github.com/wasmerio/wasmer?branch=get_namespace_exports#35d6c0229c1f85969053d695f89cbdc5586d6392"
+dependencies = [
+ "backtrace",
+ "lazy_static",
+ "loupe",
+ "memmap2",
+ "more-asserts",
+ "rustc-demangle",
+ "serde",
+ "serde_bytes",
+ "target-lexicon",
+ "thiserror",
+ "wasmer-compiler",
+ "wasmer-types",
+ "wasmer-vm",
+]
+
+[[package]]
+name = "wasmer-engine-dylib"
+version = "2.0.0"
+source = "git+https://github.com/wasmerio/wasmer?branch=get_namespace_exports#35d6c0229c1f85969053d695f89cbdc5586d6392"
+dependencies = [
+ "cfg-if 1.0.0",
+ "leb128",
+ "libloading",
+ "loupe",
+ "rkyv",
+ "serde",
+ "tempfile",
+ "tracing",
+ "wasmer-compiler",
+ "wasmer-engine",
+ "wasmer-object",
+ "wasmer-types",
+ "wasmer-vm",
+ "which",
+]
+
+[[package]]
+name = "wasmer-engine-universal"
+version = "2.0.0"
+source = "git+https://github.com/wasmerio/wasmer?branch=get_namespace_exports#35d6c0229c1f85969053d695f89cbdc5586d6392"
+dependencies = [
+ "cfg-if 1.0.0",
+ "leb128",
+ "loupe",
+ "region 3.0.0",
+ "rkyv",
+ "wasmer-compiler",
+ "wasmer-engine",
+ "wasmer-types",
+ "wasmer-vm",
+ "winapi",
+]
+
+[[package]]
+name = "wasmer-object"
+version = "2.0.0"
+source = "git+https://github.com/wasmerio/wasmer?branch=get_namespace_exports#35d6c0229c1f85969053d695f89cbdc5586d6392"
+dependencies = [
+ "object",
+ "thiserror",
+ "wasmer-compiler",
+ "wasmer-types",
+]
+
+[[package]]
+name = "wasmer-types"
+version = "2.0.0"
+source = "git+https://github.com/wasmerio/wasmer?branch=get_namespace_exports#35d6c0229c1f85969053d695f89cbdc5586d6392"
+dependencies = [
+ "indexmap",
+ "loupe",
+ "rkyv",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "wasmer-vfs"
+version = "2.0.0"
+source = "git+https://github.com/wasmerio/wasmer?branch=get_namespace_exports#35d6c0229c1f85969053d695f89cbdc5586d6392"
+dependencies = [
+ "libc",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "wasmer-vm"
+version = "2.0.0"
+source = "git+https://github.com/wasmerio/wasmer?branch=get_namespace_exports#35d6c0229c1f85969053d695f89cbdc5586d6392"
+dependencies = [
+ "backtrace",
+ "cc",
+ "cfg-if 1.0.0",
+ "indexmap",
+ "libc",
+ "loupe",
+ "memoffset",
+ "more-asserts",
+ "region 3.0.0",
+ "rkyv",
+ "serde",
+ "thiserror",
+ "wasmer-types",
+ "winapi",
+]
+
+[[package]]
+name = "wasmer-wasi"
+version = "2.0.0"
+source = "git+https://github.com/wasmerio/wasmer?branch=get_namespace_exports#35d6c0229c1f85969053d695f89cbdc5586d6392"
+dependencies = [
+ "cfg-if 1.0.0",
+ "generational-arena",
+ "getrandom 0.2.3",
+ "libc",
+ "thiserror",
+ "tracing",
+ "wasm-bindgen",
+ "wasmer",
+ "wasmer-vfs",
+ "wasmer-wasi-types",
+ "winapi",
+]
+
+[[package]]
+name = "wasmer-wasi-types"
+version = "2.0.0"
+source = "git+https://github.com/wasmerio/wasmer?branch=get_namespace_exports#35d6c0229c1f85969053d695f89cbdc5586d6392"
+dependencies = [
+ "byteorder",
+ "serde",
+ "time",
+ "wasmer-types",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.78.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52144d4c78e5cf8b055ceab8e5fa22814ce4315d6002ad32cfd914f37c12fd65"
 
 [[package]]
 name = "wasmparser"
@@ -1387,7 +2015,7 @@ dependencies = [
  "anyhow",
  "backtrace",
  "bincode",
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpp_demangle",
  "indexmap",
  "lazy_static",
@@ -1397,11 +2025,11 @@ dependencies = [
  "paste",
  "psm",
  "rayon",
- "region",
+ "region 2.2.0",
  "rustc-demangle",
  "serde",
  "target-lexicon",
- "wasmparser",
+ "wasmparser 0.80.2",
  "wasmtime-cache",
  "wasmtime-cranelift",
  "wasmtime-environ",
@@ -1440,9 +2068,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99706bacdf5143f7f967d417f0437cce83a724cf4518cb1a3ff40e519d793021"
 dependencies = [
  "anyhow",
- "cranelift-codegen",
- "cranelift-entity",
- "cranelift-frontend",
+ "cranelift-codegen 0.77.0",
+ "cranelift-entity 0.77.0",
+ "cranelift-frontend 0.77.0",
  "cranelift-native",
  "cranelift-wasm",
  "gimli",
@@ -1450,7 +2078,7 @@ dependencies = [
  "object",
  "target-lexicon",
  "thiserror",
- "wasmparser",
+ "wasmparser 0.80.2",
  "wasmtime-environ",
 ]
 
@@ -1461,8 +2089,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac42cb562a2f98163857605f02581d719a410c5abe93606128c59a10e84de85b"
 dependencies = [
  "anyhow",
- "cfg-if",
- "cranelift-entity",
+ "cfg-if 1.0.0",
+ "cranelift-entity 0.77.0",
  "gimli",
  "indexmap",
  "log",
@@ -1471,7 +2099,7 @@ dependencies = [
  "serde",
  "target-lexicon",
  "thiserror",
- "wasmparser",
+ "wasmparser 0.80.2",
  "wasmtime-types",
 ]
 
@@ -1495,17 +2123,17 @@ dependencies = [
  "addr2line",
  "anyhow",
  "bincode",
- "cfg-if",
+ "cfg-if 1.0.0",
  "gimli",
  "libc",
  "log",
  "more-asserts",
  "object",
- "region",
+ "region 2.2.0",
  "serde",
  "target-lexicon",
  "thiserror",
- "wasmparser",
+ "wasmparser 0.80.2",
  "wasmtime-environ",
  "wasmtime-runtime",
  "winapi",
@@ -1520,7 +2148,7 @@ dependencies = [
  "anyhow",
  "backtrace",
  "cc",
- "cfg-if",
+ "cfg-if 1.0.0",
  "indexmap",
  "lazy_static",
  "libc",
@@ -1529,7 +2157,7 @@ dependencies = [
  "memoffset",
  "more-asserts",
  "rand 0.8.4",
- "region",
+ "region 2.2.0",
  "thiserror",
  "wasmtime-environ",
  "wasmtime-fiber",
@@ -1542,10 +2170,10 @@ version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9b01caf8a204ef634ebac99700e77ba716d3ebbb68a1abbc2ceb6b16dbec9e4"
 dependencies = [
- "cranelift-entity",
+ "cranelift-entity 0.77.0",
  "serde",
  "thiserror",
- "wasmparser",
+ "wasmparser 0.80.2",
 ]
 
 [[package]]
@@ -1586,6 +2214,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adcfaeb27e2578d2c6271a45609f4a055e6d7ba3a12eff35b1fd5ba147bdf046"
 dependencies = [
  "wast 38.0.1",
+]
+
+[[package]]
+name = "which"
+version = "4.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea187a8ef279bc014ec368c27a920da2024d2a711109bfbe3440585d5cf27ad9"
+dependencies = [
+ "either",
+ "lazy_static",
+ "libc",
 ]
 
 [[package]]
@@ -1688,10 +2327,28 @@ dependencies = [
 [[package]]
 name = "witx-bindgen-gen-core"
 version = "0.1.0"
+source = "git+https://github.com/wasmerio/witx-bindgen?branch=wasmer-preview-20211001#055e7d226146476ca705ac7ab1c0c2fcac97b684"
+dependencies = [
+ "anyhow",
+ "witx2 0.1.0 (git+https://github.com/wasmerio/witx-bindgen?branch=wasmer-preview-20211001)",
+]
+
+[[package]]
+name = "witx-bindgen-gen-core"
+version = "0.1.0"
 source = "git+https://github.com/bytecodealliance/witx-bindgen#0b80c6df4715130c963f8d09b3d99a7c95dd8e63"
 dependencies = [
  "anyhow",
- "witx2",
+ "witx2 0.1.0 (git+https://github.com/bytecodealliance/witx-bindgen)",
+]
+
+[[package]]
+name = "witx-bindgen-gen-rust"
+version = "0.1.0"
+source = "git+https://github.com/wasmerio/witx-bindgen?branch=wasmer-preview-20211001#055e7d226146476ca705ac7ab1c0c2fcac97b684"
+dependencies = [
+ "heck",
+ "witx-bindgen-gen-core 0.1.0 (git+https://github.com/wasmerio/witx-bindgen?branch=wasmer-preview-20211001)",
 ]
 
 [[package]]
@@ -1700,7 +2357,7 @@ version = "0.1.0"
 source = "git+https://github.com/bytecodealliance/witx-bindgen#0b80c6df4715130c963f8d09b3d99a7c95dd8e63"
 dependencies = [
  "heck",
- "witx-bindgen-gen-core",
+ "witx-bindgen-gen-core 0.1.0 (git+https://github.com/bytecodealliance/witx-bindgen)",
 ]
 
 [[package]]
@@ -1709,8 +2366,18 @@ version = "0.1.0"
 source = "git+https://github.com/bytecodealliance/witx-bindgen#0b80c6df4715130c963f8d09b3d99a7c95dd8e63"
 dependencies = [
  "heck",
- "witx-bindgen-gen-core",
- "witx-bindgen-gen-rust",
+ "witx-bindgen-gen-core 0.1.0 (git+https://github.com/bytecodealliance/witx-bindgen)",
+ "witx-bindgen-gen-rust 0.1.0 (git+https://github.com/bytecodealliance/witx-bindgen)",
+]
+
+[[package]]
+name = "witx-bindgen-gen-wasmer"
+version = "0.1.0"
+source = "git+https://github.com/wasmerio/witx-bindgen?branch=wasmer-preview-20211001#055e7d226146476ca705ac7ab1c0c2fcac97b684"
+dependencies = [
+ "heck",
+ "witx-bindgen-gen-core 0.1.0 (git+https://github.com/wasmerio/witx-bindgen?branch=wasmer-preview-20211001)",
+ "witx-bindgen-gen-rust 0.1.0 (git+https://github.com/wasmerio/witx-bindgen?branch=wasmer-preview-20211001)",
 ]
 
 [[package]]
@@ -1719,8 +2386,8 @@ version = "0.1.0"
 source = "git+https://github.com/bytecodealliance/witx-bindgen#0b80c6df4715130c963f8d09b3d99a7c95dd8e63"
 dependencies = [
  "heck",
- "witx-bindgen-gen-core",
- "witx-bindgen-gen-rust",
+ "witx-bindgen-gen-core 0.1.0 (git+https://github.com/bytecodealliance/witx-bindgen)",
+ "witx-bindgen-gen-rust 0.1.0 (git+https://github.com/bytecodealliance/witx-bindgen)",
 ]
 
 [[package]]
@@ -1739,8 +2406,31 @@ source = "git+https://github.com/bytecodealliance/witx-bindgen#0b80c6df4715130c9
 dependencies = [
  "proc-macro2",
  "syn",
- "witx-bindgen-gen-core",
+ "witx-bindgen-gen-core 0.1.0 (git+https://github.com/bytecodealliance/witx-bindgen)",
  "witx-bindgen-gen-rust-wasm",
+]
+
+[[package]]
+name = "witx-bindgen-wasmer"
+version = "0.1.0"
+source = "git+https://github.com/wasmerio/witx-bindgen?branch=wasmer-preview-20211001#055e7d226146476ca705ac7ab1c0c2fcac97b684"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "thiserror",
+ "wasmer",
+ "witx-bindgen-wasmer-impl",
+]
+
+[[package]]
+name = "witx-bindgen-wasmer-impl"
+version = "0.1.0"
+source = "git+https://github.com/wasmerio/witx-bindgen?branch=wasmer-preview-20211001#055e7d226146476ca705ac7ab1c0c2fcac97b684"
+dependencies = [
+ "proc-macro2",
+ "syn",
+ "witx-bindgen-gen-core 0.1.0 (git+https://github.com/wasmerio/witx-bindgen?branch=wasmer-preview-20211001)",
+ "witx-bindgen-gen-wasmer",
 ]
 
 [[package]]
@@ -1762,8 +2452,17 @@ source = "git+https://github.com/bytecodealliance/witx-bindgen#0b80c6df4715130c9
 dependencies = [
  "proc-macro2",
  "syn",
- "witx-bindgen-gen-core",
+ "witx-bindgen-gen-core 0.1.0 (git+https://github.com/bytecodealliance/witx-bindgen)",
  "witx-bindgen-gen-wasmtime",
+]
+
+[[package]]
+name = "witx2"
+version = "0.1.0"
+source = "git+https://github.com/wasmerio/witx-bindgen?branch=wasmer-preview-20211001#055e7d226146476ca705ac7ab1c0c2fcac97b684"
+dependencies = [
+ "anyhow",
+ "id-arena",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,8 @@ cargo-features = ["per-package-target"]
 [workspace]
 members = [
     "crates/example-wasmtime-host",
+    "crates/example-wasmer-host",
     "crates/example-wasm",
     "crates/wasi-interface-gen",
 ]
+default-members = ["crates/example-wasmtime-host"]

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This project implements portions of the [wasi-data](https://github.com/singlesto
 * [wasi-interface-gen](./crates/wasi-interface-gen): convenience macro for compiling rust functions and types to wasm modules using the canonical abi for wasi interface types.
 * [example-wasm](./crates/example-wasm): example crate using `wasi-interface-gen` to compile a wasm module with interface types.
 * [example-wasmtime-host](./crates/example-wasmtime-host): example of using wasmtime to load and run the `example-wasm` crate.
+* [example-wasmer-host](./crates/example-wasmer-host): example of using wasmer to load and run the `example-wasm` crate.
 
 ## devcontainer
 
@@ -28,6 +29,10 @@ A fantastic overview of the [interface types proposal](https://github.com/WebAss
 
 ```bash
 cargo run
+# also runnable with:
+# cargo run -p example-wasmtime-host
+# or
+# cargo run -p example-wasmer-host
 got: [SimpleValue { i: 20 }]
 got: [SplitOutput { c: "hello" }, SplitOutput { c: "how" }, SplitOutput { c: "are" }, SplitOutput { c: "you" }]
 got: [UserResult { id: 2, username: "lucy", email: "lucy@singlestore.com", phone: "555-123-4567" }, UserResult { id: 4, username: "bob", email: "bob@gmail.com", phone: "555-123-4567" }]

--- a/crates/example-wasmer-host/Cargo.toml
+++ b/crates/example-wasmer-host/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "example-wasmer-host"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+wasmer = { git = "https://github.com/wasmerio/wasmer", branch = "get_namespace_exports" }
+wasmer-wasi = { git = "https://github.com/wasmerio/wasmer", branch = "get_namespace_exports" }
+anyhow = "1.0"
+witx-bindgen-wasmer = { git = "https://github.com/wasmerio/witx-bindgen", branch = "wasmer-preview-20211001" }

--- a/crates/example-wasmer-host/src/main.rs
+++ b/crates/example-wasmer-host/src/main.rs
@@ -1,0 +1,134 @@
+// need to disable this lint for the export! macro below
+#![allow(clippy::needless_question_mark)]
+
+use anyhow::Result;
+use wasmer::*;
+use wasmer_wasi::WasiState;
+
+witx_bindgen_wasmer::export!({
+    src["component"]: "
+        record SimpleValue {
+            i: s64,
+        }
+
+        square: function(input: SimpleValue) -> list<SimpleValue>
+
+        record SplitInput {
+            s: string,
+            delimiter: string,
+        }
+
+        record SplitOutput {
+            c: string,
+        }
+
+        split: function(input: SplitInput) -> list<SplitOutput>
+
+        record User {
+            id: s64,
+            username: string,
+            email: string,
+            phone: string,
+        }
+
+        filter_out_bad_users: function(input: User) -> list<User>
+
+        record HilbertInput {
+            vec: list<u8>,
+            min_value: f64,
+            max_value: f64,
+            scale: f64,
+        }
+
+        record HilbertOutput {
+            idx: string,
+        }
+
+        hilbert_encode: function(input: HilbertInput) -> list<HilbertOutput>
+    "
+});
+
+fn vector_pack(input: &[f32]) -> Vec<u8> {
+    let mut output = Vec::with_capacity(input.len() * 4);
+    for f in input {
+        output.extend_from_slice(&f32::to_le_bytes(*f));
+    }
+    output
+}
+
+pub fn main() -> Result<()> {
+    // Create a store with the default engine and compiler.
+    let store = Store::default();
+
+    // Compile the component wasm module
+    let module = Module::from_file(&store, "target/wasm32-wasi/debug/example_wasm.wasm")?;
+
+    // Create a WASI environment for the module.
+    let mut wasi_env = WasiState::new("hello").finalize()?;
+    let mut imports = wasi_env.import_object(&module)?;
+
+    // Instantiate the module and extract a witx exported interface to it.
+    let (exports, _instance) = component::Component::instantiate(&store, &module, &mut imports)?;
+
+    let input = component::SimpleValue { i: 10 };
+    let out = exports.square(input)?;
+    println!("got: {:?}", out);
+
+    let input = component::SplitInput {
+        s: "hello, how, are, you",
+        delimiter: ", ",
+    };
+    let out = exports.split(input)?;
+
+    println!("got: {:?}", out);
+
+    let users = vec![
+        component::UserParam {
+            id: 1,
+            username: "alice",
+            email: "foo@example.com",
+            phone: "555-123-4567",
+        },
+        component::UserParam {
+            id: 2,
+            username: "lucy",
+            email: "lucy@singlestore.com",
+            phone: "555-123-4567",
+        },
+        component::UserParam {
+            id: 3,
+            username: "jones",
+            email: "jones@example.net",
+            phone: "555-123-4567",
+        },
+        component::UserParam {
+            id: 4,
+            username: "bob",
+            email: "bob@gmail.com",
+            phone: "555-123-4567",
+        },
+    ];
+
+    let mut good_users = vec![];
+    for user in users {
+        let result = exports.filter_out_bad_users(user).unwrap();
+        if !result.is_empty() {
+            good_users.extend(result);
+        }
+    }
+
+    println!("got: {:?}", good_users);
+
+    let data = vec![12.0, -3.0, 5.0, 11.0, 22.0, -5.0, -6.0];
+    let data_packed = vector_pack(&data);
+    let input = component::HilbertInput {
+        vec: &data_packed,
+        min_value: -6.0,
+        max_value: 22.0,
+        scale: 100.0,
+    };
+    let out = exports.hilbert_encode(input)?;
+    println!("got: {:?}", out);
+
+    Ok(())
+}


### PR DESCRIPTION
This PR adds an example host based on wasmer, using an experimental fork of witx-bindgen that adds support for wasmer (https://github.com/wasmerio/witx-bindgen/tree/wasmer-preview-20211001).

Note that the bindings generator is still a work-in-progress and there may be API changes in the future.